### PR TITLE
add sepolia network

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ export const NETWORKS = {
         testnetID: 5,
         blockExplorerURL: "https://goerli.etherscan.io"
     },
+    // add sepolia network
     11155111: {
         name: "Sepolia",
         chain: "ethereum",

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,18 @@ export const NETWORKS = {
         testnetID: 5,
         blockExplorerURL: "https://goerli.etherscan.io"
     },
+    11155111: {
+        name: "Sepolia",
+        chain: "ethereum",
+        rpcURL: "https://eth-sepolia.g.alchemy.com/v2/9aGDv2vtcgRQ1hVm63qymgnFlKgmmRqU",
+        currency: {
+            name: "Ether",
+            symbol: "ETH",
+            decimals: 18
+        },
+        testnetID: 11155111,
+        blockExplorerURL: "https://sepolia.etherscan.io/"
+    },
     10: {
         name: "Optimism",
         chain: "ethereum",


### PR DESCRIPTION
add sepolia network support in the src/constant.js file
   11155111: {
        name: "Sepolia",
        chain: "ethereum",
        rpcURL: "https://eth-sepolia.g.alchemy.com/v2/9aGDv2vtcgRQ1hVm63qymgnFlKgmmRqU",
        currency: {
            name: "Ether",
            symbol: "ETH",
            decimals: 18
        },
        testnetID: 11155111,
        blockExplorerURL: "https://sepolia.etherscan.io/"
    }